### PR TITLE
Update build_docs for python3

### DIFF
--- a/cli/build_docs.py
+++ b/cli/build_docs.py
@@ -6,7 +6,7 @@
 # Note this assumes that build_plaac.sh has already
 # been run.
 
-import os, sys, cgi
+import sys, html
 
 with open(sys.argv[1], 'r') as doc:
     for line in doc:
@@ -15,4 +15,5 @@ with open(sys.argv[1], 'r') as doc:
             col = col[3:]
             desc = desc.strip()
 
-            print "%%li\n  %%strong %s\n  %s" % (col, cgi.escape(desc))
+            print("%%li\n  %%strong %s\n  %s" % (col, html.escape(desc)))
+


### PR DESCRIPTION
This makes build_docs.py compatible with python3, since python2 was sunset Jan 1, 2020.