### PR TITLE
Add a golden/regression test suite and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Build plaac.jar
+        working-directory: cli
+        run: ./build_plaac.sh
+
+      - name: Run golden / regression tests
+        run: cli/tests/run_tests.sh --no-build
+
+      - name: Upload actual PLAAC output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plaac-actual-output
+          path: cli/tests/actual_output.txt
+          if-no-files-found: warn

--- a/cli/tests/.gitignore
+++ b/cli/tests/.gitignore
@@ -1,0 +1,2 @@
+actual_output.txt
+*.diff

--- a/cli/tests/README.md
+++ b/cli/tests/README.md
@@ -1,0 +1,48 @@
+PLAAC command-line tests
+========================
+
+Regression tests for the PLAAC CLI. There is no external test framework
+dependency — the harness is plain `bash` + `java`, the same tools already
+needed to build and run PLAAC.
+
+Running
+-------
+
+From the repository root (or anywhere):
+
+    cli/tests/run_tests.sh
+
+This builds `cli/target/plaac.jar` if it is missing, then runs the tests. Pass
+`--no-build` to require a pre-built jar instead.
+
+What is tested
+--------------
+
+1. **Golden output** — PLAAC is run on the bundled
+   `cli/example/four_classic_prions.fasta` with `-a 1 -c 60 -d`, and its full
+   output is compared byte-for-byte against
+   [`expected/four_classic_prions.a1.c60.txt`](expected/four_classic_prions.a1.c60.txt).
+   PLAAC's scoring is deterministic (Viterbi parse over fixed frequency tables,
+   no randomness, no timestamps or host paths in the output), so any difference
+   is a real change in behavior. This locks the scientific output — including
+   the built-in frequency tables and the column set the web UI's HAML is
+   generated from — against unintended changes to `plaac.java`.
+
+2. **Known-positive recovery** — Sup35p, Ure2p, Rnq1p, and Mot3p are bona fide
+   yeast prions; the harness asserts each is assigned a called PrLD
+   (`PRDlen > 0`). This is a semantic check that still holds if the golden file
+   is deliberately regenerated after a reviewed numeric change.
+
+Reproducibility note: the harness pins the JVM locale
+(`-Duser.language=en -Duser.country=US`, `LC_ALL=C`) so number formatting is
+identical regardless of the host's default locale.
+
+Regenerating the golden file
+----------------------------
+
+The golden file is a guard, not ground truth. Regenerate it **only** when a
+change to `plaac.java` is *expected* to change the output, and only after
+reviewing the diff:
+
+    cli/tests/regenerate_golden.sh
+    git diff -- cli/tests/expected/    # review before committing

--- a/cli/tests/expected/four_classic_prions.a1.c60.txt
+++ b/cli/tests/expected/four_classic_prions.a1.c60.txt
@@ -1,0 +1,54 @@
+############################ parameters at run-time ####################################
+## alpha=1.0; corelength=60; ww1=41; ww2=41; ww3=41; adjustprolines=true;
+## fg_used: {X=0.00001;A=0.04865;C=0.00219;D=0.01638;E=0.00783;F=0.02537;G=0.07603;H=0.01810;I=0.02018;K=0.01641;L=0.02639;M=0.02975;N=0.25885;P=0.05126;Q=0.15178;R=0.02500;S=0.10988;T=0.03841;V=0.01972;W=0.00157;Y=0.05624;*=0.00001;}
+## bg_scer: {X=0.00000;A=0.05499;C=0.01260;D=0.05859;E=0.06549;F=0.04410;G=0.04980;H=0.02170;I=0.06549;K=0.07349;L=0.09499;M=0.02070;N=0.06149;P=0.04380;Q=0.03960;R=0.04440;S=0.08989;T=0.05919;V=0.05559;W=0.01040;Y=0.03370;*=0.00000;}
+## bg_input: {X=0.00000;A=0.07084;C=0.00465;D=0.03568;E=0.04705;F=0.03051;G=0.08066;H=0.03257;I=0.03723;K=0.05222;L=0.05481;M=0.02689;N=0.12410;P=0.04188;Q=0.10083;R=0.02689;S=0.09204;T=0.04498;V=0.04912;W=0.00672;Y=0.04033;*=0.00000;}
+## bg_used: {X=0.00001;A=0.05499;C=0.01260;D=0.05859;E=0.06549;F=0.04409;G=0.04979;H=0.02170;I=0.06549;K=0.07349;L=0.09499;M=0.02070;N=0.06149;P=0.04379;Q=0.03960;R=0.04439;S=0.08989;T=0.05919;V=0.05559;W=0.01040;Y=0.03370;*=0.00001;}
+## plaac_llr: {X=0.00000;A=-0.12257;C=-1.74969;D=-1.27456;E=-2.12398;F=-0.55278;G=0.42322;H=-0.18129;I=-1.17725;K=-1.49928;L=-1.28078;M=0.36281;N=1.43732;P=0.15739;Q=1.34371;R=-0.57425;S=0.20080;T=-0.43249;V=-1.03644;W=-1.89062;Y=0.51224;*=0.00000;}
+## papa_lods: {X=0.00000;A=-0.39649;C=0.41516;D=-1.27700;E=-0.60502;F=0.83873;G=-0.03922;H=-0.27857;I=0.81370;K=-1.57675;L=-0.04001;M=0.67373;N=0.08030;P=-1.19745;Q=0.06917;R=-0.40586;S=0.13391;T=-0.11457;V=0.81370;W=0.66674;Y=0.77865;*=0.00000;}
+#######################################################################################
+############################ Description of output columns ############################
+## SEQid: sequence name from fasta file
+## MW: Michelitsh-Weissman [PNAS 2000] score --- maximum number of N + Q in window of at most 80 AA
+## MWstart: index of start position of window with max MW score.
+## MWend: index of end position of window with max MW score
+## MWlen: length of window used for MW score [smaller of 80 and PROTlen].
+## LLR: max sum of PLAAC log-likelihood ratios (base 4) in window of size c [NaN if PROTlen < c]
+## LLRstart: index of start position of window with max LLR score [-1 if PROTlen < c]
+## LLRend: index of end position of window with max LLR score [-1 if PROTlen < c]
+## LLRlen: length of window used for LLR score [should be c]
+## NLLR: normalized LLR score, i.e. LLR/LLRlen [NaN if PROTlen < c]
+## VITmaxrun: maximum length of consecutive PrD state in Viterbi parse
+## COREscore: max sum of PLAAC LLRs in window of size c contained entirely within Viterbi parse [NaN if VITmaxrun < c]
+## COREstart: index of start position of window with max COREscore [-1 if VITmaxrun < c]
+## COREend: index of end position of window with max COREscore [-2 if VITmaxrun < c]
+## CORElen: length of window used for CORElen [should be either c or 0]
+## PRDscore: sum of PLAAC LLRs in full region of Viterbi parse containing CORE region, if any [NaN otherwise].
+## PRDstart: index of start position of window with PRDscore [-1 if VITmaxrun < c]
+## PRDend: index of end position of window with PRDscore [-2 if VITmaxrun < c]
+## PRDlen: length of window used for PRDscore
+## PROTlen: number of AAs in protein, not including terminal stop codon if any.
+## HMMall: log-likelihood ratio for sequence under two-state HMM vs. one-state background HMM
+## HMMvit: log-likelihood ratio for sequence under Viterbi parse of two-state HMM vs. one-state background HMM
+## COREaa: AA sequence at which COREscore is attained [- if VITmaxrun < c]
+## STARTaa: first 15 AA of PRDaa [- if VITmaxrun < c]
+## ENDaa: last 15 AA of PRDaa [- if VITmaxrun < c]
+## PRDaa: AA sequence at which PRDscore is attained [- if VITmaxrun < c]
+## FInumaa: number of AAs predicted to be disordered by FoldIndex [Prilusky et al, Bioinformatics, 2005] (exludes runs of under 5 AA)
+## FImeanhydro: hydropathy score <H> for entire protein [Uversky et al, Proteins, 2000]
+## FImeancharge: mean charge <R> for entire protein [Uversky et al, Proteins, 2000]
+## FImeancombo: disorder score for entire protein: 2.785<H> - |<R>| - 1.151 [Uversky et al, Proteins, 2000]
+## FImaxrun: length of longest run of predicted disorder by FoldIndex
+## PAPAcombo: signed distance to PAPA decision surface [as in King et al Brain Res 2012]
+## PAPAprop: maximal score of PAPA prion propensities (averges of averages) in region with negative FI score [Toombs et al MBC 2012]
+## PAPAfi: FI score (averages of averages) at PAPAcen
+## PAPAllr: PLAAC LLR score (average) at PAPAcen
+## PAPAllr2: PLAAC LLR score (average of averages) at PAPAcen
+## PAPAcen: index of center of window at which PAPAprop is obtained
+## PAPAaa: AA sequence of width W centered at PAPAcen
+#######################################################################################
+SEQid	MW	MWstart	MWend	MWlen	LLR	LLRstart	LLRend	LLRlen	NLLR	VITmaxrun	COREscore	COREstart	COREend	CORElen	PRDscore	PRDstart	PRDend	PRDlen	PROTlen	HMMall	HMMvit	COREaa	STARTaa	ENDaa	PRDaa	FInumaa	FImeanhydro	FImeancharge	FImeancombo	FImaxrun	PAPAcombo	PAPAprop	PAPAfi	PAPAllr	PAPAllr2	PAPAcen	PAPAaa
+Sup35p	38	4	83	80	51.215	5	64	60	0.854	133	51.215	5	64	60	89.773	1	133	133	685	81.820	79.598	NQGNNQQNYQQYSQNGNQQQGNNRYQGYQAYNAQAQPAGGYYQNYQGYSGYQQGGYQQYN	MSDSNQGNNQQNYQQ	PQSQGMSLNDFQKQQ	MSDSNQGNNQQNYQQYSQNGNQQQGNNRYQGYQAYNAQAQPAGGYYQNYQGYSGYQQGGYQQYNPDAGYQQQYNPQGGYQQYNPQGGYQQQFNPQGGRGNYKNFNYNNNLQGYQAGFQPQSQGMSLNDFQKQQ	366	0.411	0.004	-0.010	262	0.100	0.100	-0.423	0.861	0.814	25	NQGNNQQNYQQYSQNGNQQQGNNRYQGYQAYNAQAQPAGGY
+Ure2p	38	1	80	80	29.225	17	76	60	0.487	89	29.225	17	76	60	37.909	1	89	89	354	30.842	28.910	RQVNIGNRNSNTTTDQSNINFEFSTGVNNNNNNNSSSNNNNVQNNNSGRNGSQNNDNENN	MMNNNGNQVSNLSNA	NNIKNTLEQHRQQQQ	MMNNNGNQVSNLSNALRQVNIGNRNSNTTTDQSNINFEFSTGVNNNNNNNSSSNNNNVQNNNSGRNGSQNNDNENNIKNTLEQHRQQQQ	107	0.439	0.017	0.054	107	0.103	0.103	-0.130	0.228	0.317	21	MMNNNGNQVSNLSNALRQVNIGNRNSNTTTDQSNINFEFST
+Rnq1p	43	238	317	80	47.459	218	277	60	0.791	282	47.459	218	277	60	165.340	124	405	282	405	154.981	152.584	NNNQNSNNSQQGYNQSYQNGNQNSQGYNNQQYQGGNGGYQQQQGQSGGAFSSLASMAQSY	SGSGGGSQSMGASGL	GNFSQQNNNGNQNRY	SGSGGGSQSMGASGLAALASQFFKSGNNSQGQGQGQGQGQGQGQGQGQGSFTALASLASSFMNSNNNNQQGQNQSSGGSSFGALASMASSFMHSNNNQNSNNSQQGYNQSYQNGNQNSQGYNNQQYQGGNGGYQQQQGQSGGAFSSLASMAQSYLGGGQTQSNQQQYNQQGQNNQQQYQQQGQNYQHQQQGQQQQQGHSSSFSALASMASSYLGNNSNSNSSYGGQQQANEYGRPQQNGQQQSNEYGRPQYGGNQNSNGQHESFNFSGNFSQQNNNGNQNRY	286	0.374	0.007	-0.118	205	0.141	0.141	-0.324	0.911	0.791	234	FMHSNNNQNSNNSQQGYNQSYQNGNQNSQGYNNQQYQGGNG
+Mot3p	38	83	162	80	40.751	98	157	60	0.679	296	40.751	98	157	60	109.847	1	296	296	490	115.787	107.777	NNSNNNNVTAGNNMSASPIVHNNSNNSNNSNISASDYTVANNSTSNNNNNNNNNNNNNNN	MNADHHLQQQQQQRQ	NPSPNLNLNINPAQP	MNADHHLQQQQQQRQQHQQQQHQQQQHQHQHQQQQHTILQNVSNTNNIGSDSLASQPFNTTTVSSNKDDVMVNSGARELPMPLHQQQYIYPYYQYTSNNSNNNNVTAGNNMSASPIVHNNSNNSNNSNISASDYTVANNSTSNNNNNNNNNNNNNNNIHPNQFTAAANMNSNAAAAAYYSFPTANMPIPQQDQQYMFNPASYISHYYSAVNSNNNGNNAANNGSNNSSHSAPAPAPGPPHHHHHHSNTHNNLNNGGAVNTNNAPQHHPTIITDQFQFQLQQNPSPNLNLNINPAQP	416	0.373	-0.010	-0.122	115	0.102	0.102	-0.116	0.502	0.422	109	IYPYYQYTSNNSNNNNVTAGNNMSASPIVHNNSNNSNNSNI

--- a/cli/tests/regenerate_golden.sh
+++ b/cli/tests/regenerate_golden.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Regenerate the committed golden output. Run this ONLY when a change to
+# plaac.java is expected to change the numeric output, and after you have
+# reviewed the diff and confirmed the new numbers are correct. The golden file
+# is a guard, not ground truth -- regenerating it silently defeats the test.
+#
+# Usage: cli/tests/regenerate_golden.sh
+
+set -euo pipefail
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+JAR="$CLI_DIR/target/plaac.jar"
+EXAMPLE="$CLI_DIR/example/four_classic_prions.fasta"
+EXPECTED="$TESTS_DIR/expected/four_classic_prions.a1.c60.txt"
+
+[[ -f "$JAR" ]] || ( cd "$CLI_DIR" && ./build_plaac.sh )
+
+export LC_ALL=C
+java -Duser.language=en -Duser.country=US -jar "$JAR" \
+    -i "$EXAMPLE" -a 1 -c 60 -d > "$EXPECTED"
+
+echo "Wrote $EXPECTED"
+echo "Review the diff carefully before committing:"
+echo "  git diff -- $EXPECTED"

--- a/cli/tests/run_tests.sh
+++ b/cli/tests/run_tests.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Golden / regression tests for the PLAAC command-line application.
+#
+# PLAAC's scoring is deterministic: for a fixed input FASTA, alpha, and core
+# length its output is a pure function of the sequences and the built-in
+# frequency tables (no randomness, no timestamps, no host-specific paths). That
+# makes byte-for-byte golden comparison a valid guard against unintended changes
+# to the ~5k-line plaac.java.
+#
+# Two tests are run:
+#   1. golden     -- full output matches a committed expected file exactly.
+#   2. recovery   -- the four classic yeast prions each get a called PrLD
+#                    (PRDlen > 0). This is a semantic check that survives a
+#                    deliberate, reviewed regeneration of the golden file.
+#
+# Usage:
+#   cli/tests/run_tests.sh            # builds plaac.jar if missing, then tests
+#   cli/tests/run_tests.sh --no-build # require an existing target/plaac.jar
+#
+# Exits non-zero if any test fails.
+
+set -u
+
+# --- locate directories (this script lives in cli/tests) --------------------
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+JAR="$CLI_DIR/target/plaac.jar"
+EXAMPLE="$CLI_DIR/example/four_classic_prions.fasta"
+EXPECTED="$TESTS_DIR/expected/four_classic_prions.a1.c60.txt"
+
+# Pin the locale so number formatting (decimal separator) is reproducible on
+# CI hosts configured with a comma-decimal locale.
+export LC_ALL=C
+JAVA_LOCALE_FLAGS=(-Duser.language=en -Duser.country=US)
+
+BUILD=1
+[[ "${1:-}" == "--no-build" ]] && BUILD=0
+
+fail=0
+pass_msg() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+fail_msg() { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; fail=1; }
+
+# --- ensure the jar exists --------------------------------------------------
+if [[ ! -f "$JAR" ]]; then
+    if [[ "$BUILD" -eq 1 ]]; then
+        echo "plaac.jar not found; building..."
+        ( cd "$CLI_DIR" && ./build_plaac.sh ) || { echo "build failed"; exit 2; }
+    else
+        echo "plaac.jar not found at $JAR (run without --no-build to build it)"; exit 2
+    fi
+fi
+
+command -v java >/dev/null 2>&1 || { echo "java not found on PATH"; exit 2; }
+
+echo "Running PLAAC golden tests..."
+# Written to a stable (gitignored) path rather than a temp file so CI can upload
+# it as an artifact -- useful for diagnosing a cross-platform golden mismatch.
+ACTUAL="$TESTS_DIR/actual_output.txt"
+
+java "${JAVA_LOCALE_FLAGS[@]}" -jar "$JAR" -i "$EXAMPLE" -a 1 -c 60 -d > "$ACTUAL" 2>/dev/null
+
+# --- test 1: byte-for-byte golden -------------------------------------------
+if diff -u "$EXPECTED" "$ACTUAL" > /tmp/plaac_golden.diff 2>&1; then
+    pass_msg "golden output matches expected (four_classic_prions, -a 1 -c 60)"
+else
+    fail_msg "golden output differs from expected:"
+    sed 's/^/        /' /tmp/plaac_golden.diff | head -40
+    echo "        (if this change is intentional, regenerate with tests/regenerate_golden.sh)"
+fi
+
+# --- test 2: known-positive recovery (PRDlen > 0 for all four prions) -------
+# Find the PRDlen column index from the header row so the check does not depend
+# on a hard-coded column position.
+recovery_report="$(
+    awk -F'\t' '
+        /^#/ { next }
+        $1 == "SEQid" {
+            for (i = 1; i <= NF; i++) if ($i == "PRDlen") col = i
+            next
+        }
+        NF > 1 {
+            n++
+            if (col == 0)            { print "NO_PRDLEN_COLUMN"; bad=1; next }
+            if ($col + 0 <= 0)       { print "NOCALL " $1 " PRDlen=" $col; bad=1 }
+            else                     { print "OK " $1 " PRDlen=" $col }
+        }
+        END { if (n == 0) print "NO_DATA_ROWS"; else print "COUNT " n }
+    ' "$ACTUAL"
+)"
+
+if echo "$recovery_report" | grep -qE 'NO_PRDLEN_COLUMN|NO_DATA_ROWS|NOCALL'; then
+    fail_msg "PrLD recovery check failed:"
+    echo "$recovery_report" | sed 's/^/        /'
+elif [[ "$(echo "$recovery_report" | grep -c '^OK ')" -eq 4 ]]; then
+    pass_msg "all four classic prions call a PrLD (PRDlen > 0)"
+    echo "$recovery_report" | grep '^OK ' | sed 's/^/        /'
+else
+    fail_msg "expected 4 PrLD-positive proteins; got:"
+    echo "$recovery_report" | sed 's/^/        /'
+fi
+
+echo
+if [[ "$fail" -eq 0 ]]; then
+    echo "All tests passed."
+else
+    echo "Some tests FAILED."
+fi
+exit "$fail"


### PR DESCRIPTION
Hi maintainers, I use PLAAC in my routine workflows and wanted to add automated tests for the PLAAC CLI, plus CI to run them.

The scoring logic in `cli/src/plaac.java` currently has no automated test guarding it, so there is no safety net against an edit unintentionally changing results. PLAAC’s output is deterministic, which makes byte-for-byte regression testing straightforward.

## What this adds (pure addition — no changes to `plaac.java`)
- **`cli/tests/run_tests.sh`** — plain `bash` + `java`, no test-framework dependency. Two checks:
  1. **golden**: runs the bundled `cli/example/four_classic_prions.fasta` at `-a 1 -c 60 -d` and compares the full output byte-for-byte against a committed expected file. This locks the scored output and the built-in frequency/column tables (from which the web `_plaac_headers.haml` is generated).
  2. **recovery**: asserts the four classic yeast prions (Sup35, Ure2, Rnq1, Mot3) each get a called PrLD (`PRDlen > 0`), a semantic check that survives a reviewed, intentional regeneration of the golden file.
- **`cli/tests/expected/four_classic_prions.a1.c60.txt`** — the golden file.
- **`cli/tests/regenerate_golden.sh`** — regenerates the golden for reviewed numeric changes.
- **`cli/tests/README.md`** — docs.
- **`.github/workflows/ci.yml`** — builds `plaac.jar` and runs the suite on push/PR (JDK 17), and uploads the actual output as an artifact.

## Reproducibility
PLAAC scores use `Math.log`/`Math.exp` (platform intrinsics), so I verified the output is byte-identical across **macOS/arm64** and **Linux/x64** (Temurin 17) before committing; the harness also pins the JVM locale so number formatting is host-independent. CI is green.

## Notes
- No behavior changes; nothing outside `cli/tests/` and `.github/` is touched.
- Happy to follow up separately with CLI input-validation hardening (friendlier errors for non-numeric args, etc.) if that would be useful.