### PR TITLE
Validate command-line arguments and route diagnostics to stderr

### DIFF
--- a/.github/workflows/cli-unit-test.yml
+++ b/.github/workflows/cli-unit-test.yml
@@ -7,6 +7,7 @@ on:
       - 'cli/build_plaac.sh'
       - 'cli/build_docs.py'
       - 'cli/src/**'
+      - 'cli/tests/**'
   pull_request:
     paths: *plaac_cli_paths
 
@@ -50,3 +51,7 @@ jobs:
           diff -u \
             example/MOT3-candidates-plaac-1.1.0.tsv \
             output.tsv
+
+      - name: Run input-validation tests
+        run: |
+          bash tests/test_input_validation.sh --no-build

--- a/cli/src/plaac.java
+++ b/cli/src/plaac.java
@@ -300,6 +300,34 @@ class plaac {
     }
 
 
+    // --- command-line argument validation helpers ---------------------------
+    // Report a usage error on stderr and exit non-zero, instead of throwing a
+    // raw stack trace (e.g. a non-numeric value for a numeric option) or failing
+    // silently. Diagnostics go to stderr so they never pollute the TSV on stdout.
+    static void usageError(String msg) {
+	System.err.println("plaac: " + msg);
+	System.err.println("For usage details, run with no arguments: java -jar plaac.jar");
+	System.exit(2);
+    }
+
+    static int parseIntArg(String flag, String val) {
+	try {
+	    return Integer.parseInt(val);
+	} catch (NumberFormatException e) {
+	    usageError("option " + flag + " requires an integer, but got '" + val + "'");
+	    return 0; // unreachable: usageError calls System.exit
+	}
+    }
+
+    static double parseDoubleArg(String flag, String val) {
+	try {
+	    return Double.parseDouble(val);
+	} catch (NumberFormatException e) {
+	    usageError("option " + flag + " requires a number, but got '" + val + "'");
+	    return 0; // unreachable: usageError calls System.exit
+	}
+    }
+
     public static void main (String args[]) {
 
 	plaac ms = new plaac(); 
@@ -377,18 +405,34 @@ class plaac {
 	    else if (args[i].equals("-b")) {bgfile = args[i+1]; i++;}
 	    else if (args[i].equals("-B")) {bgfreqfile = args[i+1]; i++;}
             else if (args[i].equals("-F")) {fgfreqfile = args[i+1]; i++;}
-	    else if (args[i].equals("-c")) {corelength = Integer.parseInt(args[i+1]); i++;}
-	    else if (args[i].equals("-w")) {ww1 = Integer.parseInt(args[i+1]); i++;}
-	    else if (args[i].equals("-W")) {ww2 = Integer.parseInt(args[i+1]); i++;}
-	    else if (args[i].equals("-a")) {alpha = Double.parseDouble(args[i+1]); i++;}
-	    else if (args[i].equals("-m")) {hmmtype = Integer.parseInt(args[i+1]); i++;} // different models. not currently used
+	    else if (args[i].equals("-c")) {corelength = parseIntArg("-c", args[i+1]); i++;}
+	    else if (args[i].equals("-w")) {ww1 = parseIntArg("-w", args[i+1]); i++;}
+	    else if (args[i].equals("-W")) {ww2 = parseIntArg("-W", args[i+1]); i++;}
+	    else if (args[i].equals("-a")) {alpha = parseDoubleArg("-a", args[i+1]); i++;}
+	    else if (args[i].equals("-m")) {hmmtype = parseIntArg("-m", args[i+1]); i++;} // different models. not currently used
 	    else if (args[i].equals("-p")) {plotlist = args[i+1]; i++;}
             else if (args[i].equals("-h")) {hmmdotfile = args[i+1]; i++;} 
             else if (args[i].equals("-d")) {printheaders = true; } // don't consume another token, '-d' doesn't take an argument
 	    else if (args[i].equals("-V")) {printversion = true; } // don't consume another token, '-V' doesn't take an argument 
             else if (args[i].equals("-s")) {printparameters = false; } // don't consume another token, '-s' doesn't take an argument 
-	    else {System.out.println("# skipping unknown option " + args[i]);}
+	    else {System.err.println("plaac: skipping unknown option " + args[i]);}
             i++;
+	}
+
+	// A value-taking flag in the last position is not consumed by the loop
+	// above (there is no following token to use as its value). Warn rather
+	// than silently ignoring it, which would run plaac in an unintended mode
+	// (e.g. "-i x.fa -p" with no print-list would run summary mode instead).
+	if (i == args.length - 1) {
+	    String last = args[i];
+	    if (last.equals("-i") || last.equals("-b") || last.equals("-B")
+		|| last.equals("-F") || last.equals("-c") || last.equals("-w")
+		|| last.equals("-W") || last.equals("-a") || last.equals("-m")
+		|| last.equals("-p") || last.equals("-h")) {
+		System.err.println("plaac: option " + last + " requires a value but was given none; ignoring it.");
+	    } else if (last.startsWith("-")) {
+		System.err.println("plaac: skipping unknown option " + last);
+	    }
 	}
 
 	if (printversion) {

--- a/cli/tests/test_input_validation.sh
+++ b/cli/tests/test_input_validation.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Tests for command-line argument validation and graceful failure.
+#
+# These lock in the behavior added alongside them:
+#   - a non-numeric value for a numeric option reports a usage error on stderr
+#     and exits non-zero, instead of throwing a raw Java stack trace;
+#   - an unknown option is reported on stderr, not stdout (so it never pollutes
+#     the TSV output);
+#   - a value-taking flag with no value (e.g. a trailing "-p") is warned about
+#     rather than silently ignored, but the run still completes.
+#
+# Usage:
+#   cli/tests/test_input_validation.sh            # builds plaac.jar if missing
+#   cli/tests/test_input_validation.sh --no-build # require an existing jar
+#
+# Exits non-zero if any test fails.
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+JAR="$CLI_DIR/target/plaac.jar"
+EXAMPLE="$CLI_DIR/example/four_classic_prions.fasta"
+
+export LC_ALL=C
+
+BUILD=1
+[[ "${1:-}" == "--no-build" ]] && BUILD=0
+
+fail=0
+pass_msg() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+fail_msg() { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; fail=1; }
+
+if [[ ! -f "$JAR" ]]; then
+    if [[ "$BUILD" -eq 1 ]]; then
+        echo "plaac.jar not found; building..."
+        ( cd "$CLI_DIR" && ./build_plaac.sh ) || { echo "build failed"; exit 2; }
+    else
+        echo "plaac.jar not found at $JAR (run without --no-build to build it)"; exit 2
+    fi
+fi
+command -v java >/dev/null 2>&1 || { echo "java not found on PATH"; exit 2; }
+
+OUT="$(mktemp)"; ERR="$(mktemp)"
+trap 'rm -f "$OUT" "$ERR"' EXIT
+
+run() { # run <args...>; sets $rc and fills $OUT/$ERR
+    java -jar "$JAR" "$@" >"$OUT" 2>"$ERR"; rc=$?
+}
+
+echo "Running PLAAC input-validation tests..."
+
+# 1. sanity: a valid invocation still succeeds
+run -i "$EXAMPLE" -a 1 -c 60
+if [[ "$rc" -eq 0 && "$(grep -cE '^(Sup35p|Ure2p|Rnq1p|Mot3p)' "$OUT")" -eq 4 ]]; then
+    pass_msg "valid invocation exits 0 and prints all four proteins"
+else
+    fail_msg "valid invocation regressed (exit=$rc, rows=$(grep -cE '^(Sup35p|Ure2p|Rnq1p|Mot3p)' "$OUT"))"
+fi
+
+# 2. non-numeric alpha: usage error on stderr, non-zero exit, no stack trace
+run -i "$EXAMPLE" -a foo -c 60
+if [[ "$rc" -ne 0 ]] && grep -qi "requires a number" "$ERR" && ! grep -qi "Exception in thread" "$ERR"; then
+    pass_msg "non-numeric -a exits non-zero with a usage error (no stack trace)"
+else
+    fail_msg "non-numeric -a not handled cleanly (exit=$rc)"; sed 's/^/        /' "$ERR" | head -5
+fi
+
+# 3. non-numeric core length: usage error, non-zero exit
+run -i "$EXAMPLE" -c foo
+if [[ "$rc" -ne 0 ]] && grep -qi "requires an integer" "$ERR" && ! grep -qi "Exception in thread" "$ERR"; then
+    pass_msg "non-numeric -c exits non-zero with a usage error (no stack trace)"
+else
+    fail_msg "non-numeric -c not handled cleanly (exit=$rc)"; sed 's/^/        /' "$ERR" | head -5
+fi
+
+# 4. unknown option: reported on stderr, never on stdout
+run -i "$EXAMPLE" -Z -a 1 -c 60
+if ! grep -qi "skipping" "$OUT" && grep -qi "skipping unknown option" "$ERR"; then
+    pass_msg "unknown option is reported on stderr, not stdout"
+else
+    fail_msg "unknown option leaked to stdout or was not reported on stderr"
+fi
+
+# 5. trailing value-flag with no value: warned, but run still completes
+run -i "$EXAMPLE" -a 1 -c 60 -p
+if [[ "$rc" -eq 0 ]] && grep -qi "requires a value but was given none" "$ERR" \
+   && [[ "$(grep -cE '^(Sup35p|Ure2p|Rnq1p|Mot3p)' "$OUT")" -eq 4 ]]; then
+    pass_msg "trailing value-flag warns on stderr but the run completes"
+else
+    fail_msg "trailing value-flag not handled as expected (exit=$rc)"; sed 's/^/        /' "$ERR" | head -5
+fi
+
+echo
+if [[ "$fail" -eq 0 ]]; then
+    echo "All input-validation tests passed."
+else
+    echo "Some input-validation tests FAILED."
+fi
+exit "$fail"


### PR DESCRIPTION
Targets `devel`. Small, self-contained CLI-robustness change that addresses the argument-parser TODOs in `plaac.java` (`// should check for valid input here!`).

**No scoring behavior changes** — `devel`’s MOT3 regression test stays byte-identical, and the versioning added in `devel` (`-V` / `VERSION`) is untouched.

## What it fixes
| Before (on `devel`) | After |
|---|---|
| `-a foo` / `-c foo` → raw `NumberFormatException` stack trace, **exit 0** | clear usage error on **stderr**, **exit 2** |
| `# skipping unknown option` printed to **stdout** → mixed into the TSV | routed to **stderr** |
| `-i x.fa -p` (value-flag with no value, last position) → silently runs summary mode | **stderr** warning; the run still completes |

All diagnostics now go to stderr, so stdout stays a clean TSV.

## Tests
`cli/tests/test_input_validation.sh` covers all three fixes plus a valid-invocation sanity check, wired into `cli-unit-test.yml` as an extra step (so it runs on the existing Java 11 + 17 matrix). Verified locally: the MOT3 gold diff still passes and `-V` still prints the version.

## Compatibility
`build_plaac.sh` still runs `plaac.jar -i dummy` to generate the web doc headers; that path is deliberately left non-fatal, so the build is unaffected. The web app builds its command with validated args and captures stderr separately, so the exit-code and stderr changes are compatible.