### PR TITLE
Add a Python API for running PLAAC and parsing its output

### DIFF
--- a/.github/workflows/cli-unit-test.yml
+++ b/.github/workflows/cli-unit-test.yml
@@ -68,7 +68,7 @@ jobs:
           bash tests/test_input_validation.sh --no-build
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/cli-unit-test.yml
+++ b/.github/workflows/cli-unit-test.yml
@@ -8,6 +8,7 @@ on:
       - 'cli/build_docs.py'
       - 'cli/src/**'
       - 'cli/tests/**'
+      - 'cli/python/**'
   pull_request:
     paths: *plaac_cli_paths
   release:
@@ -65,6 +66,17 @@ jobs:
       - name: Run input-validation tests
         run: |
           bash tests/test_input_validation.sh --no-build
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run Python wrapper tests
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pytest python -v
 
       - name: Upload jar artifact
         if: matrix.java == 11

--- a/cli/python/.gitignore
+++ b/cli/python/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.egg-info/
+build/
+dist/
+# The jar is a build artifact copied in before packaging, not source.
+plaac/plaac.jar
+# setuptools-scm writes this when configured to; not used here but ignore anyway.
+plaac/_version.py

--- a/cli/python/README.md
+++ b/cli/python/README.md
@@ -1,0 +1,102 @@
+PLAAC Python API
+================
+
+A small Python wrapper around the PLAAC command-line jar, for driving PLAAC from
+scripts and pipelines instead of shelling out by hand. It locates the jar, runs
+it with reproducible settings, checks for failure, and parses the per-protein
+output into structured rows.
+
+The core module is **standard-library only**. pandas is optional and used only by
+`PlaacRun.to_dataframe()`.
+
+Prerequisites
+-------------
+
+- A Java runtime on `PATH` (to run the jar).
+- A `plaac.jar`. The published wheel **bundles a precompiled jar**, so an
+  installed package is self-contained. When working from a source checkout,
+  build it once:
+
+      cd cli && ./build_plaac.sh      # produces cli/target/plaac.jar
+
+  The wrapper finds the jar automatically (see *Locating the jar* below).
+
+Install
+-------
+
+Install the wheel from a GitHub release (it bundles `plaac.jar`), or build a
+self-contained wheel from a source checkout after building the jar:
+
+    cd cli && ./build_plaac.sh
+    cp target/plaac.jar python/plaac/plaac.jar     # bundle the built jar
+    pip install ./python                            # or: pip install "./python[pandas]"
+
+The package version is derived from the Git tag via `setuptools-scm` — the same
+single source of truth the CLI build uses — so the CLI and the Python package in
+a release report the same version.
+
+For development, add the directory to `PYTHONPATH` / `sys.path` and `import
+plaac`; the wrapper will use a jar built in `cli/target/`.
+
+Usage
+-----
+
+```python
+import plaac
+
+# Per-protein (summary) mode: run.rows is a list of dicts, one per protein.
+run = plaac.run("cli/example/four_classic_prions.fasta", alpha=1, core_length=60)
+
+for row in plaac.called_prlds(run.rows):        # proteins with PRDlen > 0
+    print(row["SEQid"], row["PRDscore"], row["PRDlen"])
+
+df = run.to_dataframe()                          # optional; requires pandas
+
+# Per-residue mode (for plotting): run.rows is None, data is in run.stdout.
+per_res = plaac.run("input.fasta", print_list="all")
+```
+
+Key parameters of `plaac.run()` (they mirror the CLI):
+
+| Parameter | CLI flag | Notes |
+|---|---|---|
+| `alpha` | `-a` | background-frequency blend (default 1.0 = S. cerevisiae) |
+| `core_length` | `-c` | minimum called-domain length (default 60) |
+| `background_fasta` | `-b` | compute background from another FASTA |
+| `background_freqs` | `-B` | background from a frequency table |
+| `print_list` | `-p` | `"all"` or a path → per-residue output |
+| `heap` | `-Xmx` | e.g. `"4g"`; reproducible memory instead of a RAM fraction |
+| `timeout` | — | seconds; PLAAC prints no progress, so this bounds hung runs |
+| `check` | — | raise `PlaacError` on non-zero exit (default `True`) |
+| `extra_args` | — | appended verbatim for options not modeled here |
+
+Locating the jar
+----------------
+
+`plaac.run()` (via `plaac.find_jar()`) resolves the jar as follows:
+
+1. an explicit `jar=...` argument, or
+2. the `PLAAC_JAR` environment variable.
+
+   Either is treated as an instruction: if given but no file exists there,
+   resolution **fails** rather than silently using a different jar.
+3. If neither is given, it looks for a jar **bundled inside the installed
+   package** (`plaac/plaac.jar`, present in the released wheel), then falls back
+   to `cli/target/plaac.jar` (built) and `web/bin/plaac.jar` (shipped) in a
+   source checkout.
+
+Reproducibility
+---------------
+
+The wrapper pins the JVM locale (`-Duser.language=en -Duser.country=US`) so
+number formatting does not depend on the host locale — the same reason the test
+suite in `cli/tests/` does.
+
+Testing
+-------
+
+    pip install pytest      # or: pip install "./cli/python[test]"
+    pytest cli/python -v
+
+Pure-parsing tests run anywhere; the end-to-end tests self-skip if `plaac.jar`
+or Java is unavailable.

--- a/cli/python/README.md
+++ b/cli/python/README.md
@@ -82,8 +82,22 @@ Locating the jar
    resolution **fails** rather than silently using a different jar.
 3. If neither is given, it looks for a jar **bundled inside the installed
    package** (`plaac/plaac.jar`, present in the released wheel), then falls back
-   to `cli/target/plaac.jar` (built) and `web/bin/plaac.jar` (shipped) in a
-   source checkout.
+   to `cli/target/plaac.jar` (built) in a source checkout.
+
+(The web app's `web/bin/plaac.jar` is deliberately *not* searched — it is
+managed separately and would be the most likely to differ in version.)
+
+Version matching
+----------------
+
+The Java implementation and the Python package must be the same version. By
+default `plaac.run()` checks the jar's version (via `plaac.jar -V`) against
+`plaac.__version__` and raises on a mismatch — so a stale or mismatched jar is
+surfaced, not silently used. A **release wheel bundles a matching jar** by
+construction, so this never fires there. In a source checkout the installed
+package version may be `"unknown"`, in which case the check is a no-op; if you
+install the package *and* a jar built from a different checkout is found, the
+check tells you to rebuild. Pass `check_jar_version=False` to bypass it.
 
 Reproducibility
 ---------------

--- a/cli/python/plaac/__init__.py
+++ b/cli/python/plaac/__init__.py
@@ -30,6 +30,7 @@ import os
 import shutil
 import subprocess
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional, Sequence, Union
 
@@ -91,11 +92,12 @@ def find_jar(explicit: Optional[PathLike] = None) -> Path:
 
     here = Path(__file__).resolve().parent          # .../cli/python/plaac
     cli_dir = here.parent.parent                     # .../cli
-    repo_dir = cli_dir.parent                        # repo root
+    # web/bin/plaac.jar is deliberately NOT searched: it is a separately-managed
+    # artifact for the web app and is the most likely to differ in version from
+    # the Python package, which would trip the version-skew check (check_version).
     discovered = [
         here / "plaac.jar",                          # bundled in the wheel (self-contained)
         cli_dir / "target" / "plaac.jar",            # built in a source checkout
-        repo_dir / "web" / "bin" / "plaac.jar",      # shipped with the web app
     ]
     for c in discovered:
         if c.is_file():
@@ -106,6 +108,44 @@ def find_jar(explicit: Optional[PathLike] = None) -> Path:
         "it with cli/build_plaac.sh, or pass jar=... / set $PLAAC_JAR. "
         "Searched:\n  " + searched
     )
+
+
+@lru_cache(maxsize=None)
+def get_jar_version(jar_path: PathLike, java: str = "java") -> str:
+    """Return the version a PLAAC jar reports via its ``-V`` flag.
+
+    Cached per (jar, java) so it costs at most one JVM start per jar in a
+    process. Raises :class:`PlaacError` if the version cannot be parsed.
+    """
+    result = subprocess.run(
+        [java, "-jar", str(jar_path), "-V"],
+        check=True, capture_output=True, text=True,
+    )
+    output = result.stdout.strip()
+    prefix = "PLAAC Version: "                        # human-readable prefix to strip
+    if not output.startswith(prefix):
+        raise PlaacError(f"Could not determine PLAAC jar version from: {output!r}")
+    return output[len(prefix):].strip()
+
+
+def check_version(jar_path: PathLike, java: str = "java") -> str:
+    """Raise if the jar's version differs from the installed package version.
+
+    The jar and the Python bindings can drift out of sync -- especially if a
+    prebuilt jar is picked up -- so we require them to match exactly. This is a
+    no-op when the package version is ``"unknown"`` (e.g. running from a source
+    tree that was never installed), so it only enforces a match for installed
+    packages; a release wheel's bundled jar always matches by construction.
+    Returns the jar version.
+    """
+    jar_version = get_jar_version(jar_path, java)
+    if __version__ != "unknown" and jar_version != __version__:
+        raise PlaacError(
+            f"PLAAC version mismatch: the Python package is {__version__} but the "
+            f"jar at {jar_path} reports {jar_version}. Rebuild the jar from the "
+            f"same checkout (cli/build_plaac.sh), or pass jar= / set $PLAAC_JAR."
+        )
+    return jar_version
 
 
 def _coerce(value: str) -> Any:
@@ -211,6 +251,7 @@ def run(
     heap: Optional[str] = None,
     timeout: Optional[float] = None,
     check: bool = True,
+    check_jar_version: bool = True,
     extra_args: Optional[Sequence[str]] = None,
 ) -> PlaacRun:
     """Run PLAAC on a protein FASTA and return a :class:`PlaacRun`.
@@ -224,7 +265,9 @@ def run(
     (``-c``), ``background_fasta`` (``-b``), ``background_freqs`` (``-B``),
     ``print_list`` (``-p``). ``heap`` sets ``-Xmx`` (e.g. ``"4g"``); ``timeout``
     is in seconds; ``check=True`` raises on a non-zero exit; ``extra_args`` is
-    appended verbatim for options not modeled here.
+    appended verbatim for options not modeled here. ``check_jar_version=True``
+    verifies the jar's version matches this package's (skip with ``False`` for a
+    deliberately mismatched jar).
     """
     if isinstance(extra_args, str):
         raise TypeError(
@@ -234,6 +277,8 @@ def run(
     jar_path = find_jar(jar)
     if shutil.which(java) is None:
         raise PlaacError(f"'{java}' not found on PATH. Install a Java runtime (JRE).")
+    if check_jar_version:
+        check_version(jar_path, java)
     input_path = Path(input_fasta)
     if not input_path.is_file():
         raise PlaacError(f"Input FASTA not found: {input_path}")

--- a/cli/python/plaac/__init__.py
+++ b/cli/python/plaac/__init__.py
@@ -1,0 +1,282 @@
+"""
+plaac.py -- a small Python API for the PLAAC command-line tool.
+
+PLAAC (https://github.com/whitehead/plaac) is distributed as a Java jar. This
+module wraps it so PLAAC can be driven from Python without hand-rolling a
+subprocess call every time: it locates the jar, runs it with reproducible
+settings, checks for failure, and parses the tab-separated per-protein output
+into structured rows.
+
+Design notes:
+  * Standard library only. ``PlaacRun.to_dataframe()`` uses pandas if it is
+    installed, but pandas is not required for anything else.
+  * The JVM locale is pinned so number formatting is identical regardless of the
+    host locale (a comma-decimal locale would otherwise change the output text).
+  * ``timeout`` is exposed because PLAAC prints no progress: on a large proteome
+    a slow run is indistinguishable from a hung one except by this bound.
+  * ``heap`` sets ``-Xmx`` explicitly so memory use is reproducible across
+    machines rather than defaulting to a fraction of physical RAM.
+
+Example:
+    >>> import plaac
+    >>> run = plaac.run("cli/example/four_classic_prions.fasta", alpha=1, core_length=60)
+    >>> [r["SEQid"] for r in plaac.called_prlds(run.rows)]
+    ['Sup35p', 'Ure2p', 'Rnq1p', 'Mot3p']
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Sequence, Union
+
+# Package version, derived from the Git tag via setuptools-scm at build time and
+# read here from the installed distribution metadata (the same single source of
+# truth the Java CLI uses). "unknown" when running from an unbuilt source tree.
+try:
+    from importlib.metadata import version as _pkg_version, PackageNotFoundError
+    try:
+        __version__ = _pkg_version("plaac")
+    except PackageNotFoundError:
+        __version__ = "unknown"
+except ImportError:  # pragma: no cover -- importlib.metadata is in 3.8+
+    __version__ = "unknown"
+
+DEFAULT_ALPHA = 1.0
+DEFAULT_CORE_LENGTH = 60
+
+# Pin number formatting (decimal separator) so output is host-locale independent.
+_LOCALE_FLAGS = ["-Duser.language=en", "-Duser.country=US"]
+
+# Placeholders PLAAC writes for undefined values.
+_NA_TOKENS = {"NA", "NaN", "nan", ""}
+
+# Columns that hold names or amino-acid sequences; kept as strings (never coerced
+# to numbers, and their "-" placeholder is left intact rather than made None).
+_STRING_COLUMNS = {"SEQid", "COREaa", "STARTaa", "ENDaa", "PRDaa", "PAPAaa",
+                   "PRDall", "PRDothers"}
+
+PathLike = Union[str, "os.PathLike[str]"]
+
+
+class PlaacError(RuntimeError):
+    """Raised when the PLAAC jar cannot be found or the run fails."""
+
+
+def find_jar(explicit: Optional[PathLike] = None) -> Path:
+    """Locate ``plaac.jar``.
+
+    An explicit ``jar=`` path or a ``$PLAAC_JAR`` setting is treated as an
+    instruction, not a hint: if one is given but no file exists there, this
+    raises rather than silently falling back to a different jar. Otherwise it
+    looks for a jar bundled inside the installed package (so a pip-installed
+    wheel is self-contained), then falls back to the jar's usual built and
+    shipped locations in a source checkout.
+    """
+    if explicit is not None:
+        p = Path(explicit)
+        if p.is_file():
+            return p.resolve()
+        raise PlaacError(f"plaac.jar not found at the path given (jar=): {explicit}")
+
+    env = os.environ.get("PLAAC_JAR")
+    if env:
+        p = Path(env)
+        if p.is_file():
+            return p.resolve()
+        raise PlaacError(f"$PLAAC_JAR is set but no file exists there: {env}")
+
+    here = Path(__file__).resolve().parent          # .../cli/python/plaac
+    cli_dir = here.parent.parent                     # .../cli
+    repo_dir = cli_dir.parent                        # repo root
+    discovered = [
+        here / "plaac.jar",                          # bundled in the wheel (self-contained)
+        cli_dir / "target" / "plaac.jar",            # built in a source checkout
+        repo_dir / "web" / "bin" / "plaac.jar",      # shipped with the web app
+    ]
+    for c in discovered:
+        if c.is_file():
+            return c.resolve()
+    searched = "\n  ".join(str(c) for c in discovered)
+    raise PlaacError(
+        "Could not find plaac.jar. Install the wheel (which bundles it), build "
+        "it with cli/build_plaac.sh, or pass jar=... / set $PLAAC_JAR. "
+        "Searched:\n  " + searched
+    )
+
+
+def _coerce(value: str) -> Any:
+    """Convert an output cell to int/float/None; leave anything else as str."""
+    if value in _NA_TOKENS:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def parse_summary(text: str) -> list[dict[str, Any]]:
+    """Parse PLAAC per-protein (summary) output into a list of dicts.
+
+    Comment lines (starting with ``#``) are skipped; the column header is the
+    line starting with ``SEQid``. Numeric cells are coerced to int/float and
+    PLAAC's undefined placeholders (``NA``/``NaN``) become ``None``. Name and
+    amino-acid-sequence columns are kept as strings.
+
+    Raises :class:`PlaacError` if the output contains data but no column header
+    (i.e. it is malformed or from an unexpected mode), or if a data row has more
+    fields than the header (a sign the output drifted) -- both are surfaced
+    rather than silently returning empty or dropping columns. Output that is
+    empty or all comments returns ``[]``.
+    """
+    header: Optional[list[str]] = None
+    rows: list[dict[str, Any]] = []
+    saw_content = False
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        saw_content = True
+        fields = line.split("\t")
+        if header is None:
+            if fields[0] == "SEQid":
+                header = fields
+            continue
+        if len(fields) > len(header):
+            raise PlaacError(
+                "malformed PLAAC output: a data row has more fields "
+                f"({len(fields)}) than the header ({len(header)}); "
+                f"row starts with {fields[0]!r}"
+            )
+        row: dict[str, Any] = {}
+        for i, name in enumerate(header):
+            raw = fields[i] if i < len(fields) else ""
+            row[name] = raw if name in _STRING_COLUMNS else _coerce(raw)
+        rows.append(row)
+    if header is None and saw_content:
+        raise PlaacError(
+            "could not find the PLAAC column header (a line starting with "
+            "'SEQid') in the output; it may be malformed or from an unexpected "
+            "mode"
+        )
+    return rows
+
+
+def called_prlds(rows: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the rows with a called prion-like domain (``PRDlen > 0``)."""
+    out = []
+    for r in rows:
+        prdlen = r.get("PRDlen")
+        if isinstance(prdlen, (int, float)) and prdlen > 0:
+            out.append(r)
+    return out
+
+
+@dataclass
+class PlaacRun:
+    """The result of a single PLAAC invocation."""
+
+    command: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    rows: Optional[list[dict[str, Any]]]  # parsed summary rows; None in per-residue mode
+
+    def to_dataframe(self):
+        """Return the summary rows as a pandas DataFrame (pandas required)."""
+        if self.rows is None:
+            raise PlaacError(
+                "No summary rows to convert (per-residue mode). Use .stdout instead."
+            )
+        import pandas as pd  # optional dependency, imported lazily
+        return pd.DataFrame(self.rows)
+
+
+def run(
+    input_fasta: PathLike,
+    *,
+    jar: Optional[PathLike] = None,
+    alpha: float = DEFAULT_ALPHA,
+    core_length: int = DEFAULT_CORE_LENGTH,
+    background_fasta: Optional[PathLike] = None,
+    background_freqs: Optional[PathLike] = None,
+    print_list: Optional[str] = None,
+    java: str = "java",
+    heap: Optional[str] = None,
+    timeout: Optional[float] = None,
+    check: bool = True,
+    extra_args: Optional[Sequence[str]] = None,
+) -> PlaacRun:
+    """Run PLAAC on a protein FASTA and return a :class:`PlaacRun`.
+
+    In the default (summary) mode ``run.rows`` holds one parsed dict per protein.
+    Pass ``print_list="all"`` or a path to a list of sequence names to get
+    per-residue output instead; then ``run.rows`` is ``None`` and the data is in
+    ``run.stdout``.
+
+    Parameters mirror the PLAAC CLI: ``alpha`` (``-a``), ``core_length``
+    (``-c``), ``background_fasta`` (``-b``), ``background_freqs`` (``-B``),
+    ``print_list`` (``-p``). ``heap`` sets ``-Xmx`` (e.g. ``"4g"``); ``timeout``
+    is in seconds; ``check=True`` raises on a non-zero exit; ``extra_args`` is
+    appended verbatim for options not modeled here.
+    """
+    if isinstance(extra_args, str):
+        raise TypeError(
+            "extra_args must be a sequence of strings, not a single str "
+            f"(got {extra_args!r}); pass e.g. ['-s'], not '-s'"
+        )
+    jar_path = find_jar(jar)
+    if shutil.which(java) is None:
+        raise PlaacError(f"'{java}' not found on PATH. Install a Java runtime (JRE).")
+    input_path = Path(input_fasta)
+    if not input_path.is_file():
+        raise PlaacError(f"Input FASTA not found: {input_path}")
+
+    cmd = [java, *_LOCALE_FLAGS]
+    if heap:
+        cmd.append(f"-Xmx{heap}")
+    cmd += ["-jar", str(jar_path), "-i", str(input_path),
+            "-a", str(alpha), "-c", str(core_length)]
+    if background_fasta:
+        cmd += ["-b", str(background_fasta)]
+    if background_freqs:
+        cmd += ["-B", str(background_freqs)]
+    if print_list is not None:
+        cmd += ["-p", str(print_list)]
+    if extra_args is not None:
+        cmd += list(extra_args)
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError as e:  # java disappeared between the which() check and now
+        raise PlaacError(f"Failed to launch java: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise PlaacError(
+            f"PLAAC timed out after {timeout}s. PLAAC prints no progress, so a large "
+            f"proteome can look hung; raise timeout=... for big inputs."
+        ) from e
+
+    if check and proc.returncode != 0:
+        raise PlaacError(
+            f"PLAAC exited with code {proc.returncode}.\n"
+            f"Command: {' '.join(cmd)}\nstderr:\n{proc.stderr}"
+        )
+
+    # Only parse in summary mode on a successful run; a failed run (reachable
+    # only with check=False) has no meaningful rows.
+    rows = None
+    if print_list is None and proc.returncode == 0:
+        rows = parse_summary(proc.stdout)
+    return PlaacRun(
+        command=cmd,
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        rows=rows,
+    )

--- a/cli/python/pyproject.toml
+++ b/cli/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "plaac"
 description = "Python API for PLAAC (Prion-Like Amino Acid Composition)"
 readme = "README.md"
 requires-python = ">=3.8"
-license = { text = "MIT" }
+license = "MIT"
 dynamic = ["version"]
 dependencies = []
 

--- a/cli/python/pyproject.toml
+++ b/cli/python/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=61", "wheel", "setuptools-scm>=8,<9"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "plaac"
+description = "Python API for PLAAC (Prion-Like Amino Acid Composition)"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+dynamic = ["version"]
+dependencies = []
+
+[project.optional-dependencies]
+# pandas is only needed for PlaacRun.to_dataframe(); the rest is stdlib-only.
+pandas = ["pandas"]
+# development / test dependencies
+test = ["pytest"]
+
+[project.urls]
+Homepage = "https://github.com/whitehead/plaac"
+
+[tool.setuptools]
+packages = ["plaac"]
+
+[tool.setuptools.package-data]
+# The precompiled jar is copied into the package before building the wheel so
+# the installed package is self-contained (found by plaac.find_jar at runtime).
+plaac = ["plaac.jar"]
+
+# Version comes from Git tags -- the same single source of truth the CLI build
+# uses (cli/build_plaac.sh). root points to the repository root, two levels up
+# from this file; the scheme/fallback mirror the CLI so both agree.
+[tool.setuptools_scm]
+root = "../.."
+version_scheme = "guess-next-dev"
+local_scheme = "node-and-date"
+fallback_version = "1.1.0.dev0"

--- a/cli/python/test_plaac.py
+++ b/cli/python/test_plaac.py
@@ -1,0 +1,202 @@
+"""
+Tests for the plaac Python wrapper (pytest).
+
+Pure-parsing tests run anywhere; the end-to-end tests are skipped if a built
+plaac.jar or a Java runtime is unavailable.
+
+Run:  pytest cli/python           (or: cd cli/python && pytest)
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import plaac  # noqa: E402
+
+_CLI_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_EXAMPLE = os.path.join(_CLI_DIR, "example", "four_classic_prions.fasta")
+_CLASSIC = ["Sup35p", "Ure2p", "Rnq1p", "Mot3p"]
+
+
+def _jar_available():
+    import shutil
+    try:
+        plaac.find_jar()
+    except plaac.PlaacError:
+        return False
+    return shutil.which("java") is not None
+
+
+requires_jar = pytest.mark.skipif(
+    not _jar_available(), reason="plaac.jar / java not available"
+)
+
+# A small, realistic snippet of PLAAC summary output for pure-parsing tests.
+_SAMPLE = (
+    "## alpha=1.0; corelength=60;\n"
+    "SEQid\tNLLR\tPRDstart\tPRDlen\tPROTlen\tCOREaa\n"
+    "Sup35p\t0.854\t1\t133\t685\tNQGNNQQNY\n"
+    "ShortSeq\tNaN\t-1\t0\t20\t-\n"
+)
+
+
+# --- parsing (no jar needed) -------------------------------------------------
+
+def test_parse_types_and_na():
+    rows = plaac.parse_summary(_SAMPLE)
+    assert len(rows) == 2
+    r0 = rows[0]
+    assert r0["SEQid"] == "Sup35p"          # name kept as str
+    assert isinstance(r0["NLLR"], float)    # float coercion
+    assert isinstance(r0["PRDlen"], int)    # int coercion
+    assert r0["PRDlen"] == 133
+    assert r0["COREaa"] == "NQGNNQQNY"      # AA column kept as str
+    assert rows[1]["NLLR"] is None          # NaN -> None
+    assert rows[1]["COREaa"] == "-"         # '-' left intact in AA col
+
+
+def test_comment_lines_skipped():
+    rows = plaac.parse_summary(_SAMPLE)
+    assert all("SEQid" in r for r in rows)
+
+
+def test_called_prlds():
+    called = plaac.called_prlds(plaac.parse_summary(_SAMPLE))
+    assert [r["SEQid"] for r in called] == ["Sup35p"]
+
+
+def test_empty_or_comments_only_returns_empty():
+    assert plaac.parse_summary("") == []
+    assert plaac.parse_summary("## params\n# note\n") == []
+
+
+def test_header_only_returns_empty():
+    assert plaac.parse_summary("SEQid\tPRDlen\n") == []
+
+
+def test_missing_header_raises():
+    # Data present but no 'SEQid' header -> malformed, must not silently return []
+    with pytest.raises(plaac.PlaacError):
+        plaac.parse_summary("Sup35p\t0.5\t100\n")
+
+
+def test_overlong_row_raises():
+    # A data row with more fields than the header signals format drift
+    with pytest.raises(plaac.PlaacError):
+        plaac.parse_summary("SEQid\tPRDlen\nfoo\t10\textra\n")
+
+
+def test_prd_structured_columns_kept_as_strings():
+    txt = ("SEQid\tPRDcount\tPRDall\tPRDothers\n"
+           "S\t1\t{[1-133 (51.2 @ 5)];}\t{}\n")
+    row = plaac.parse_summary(txt)[0]
+    assert row["PRDcount"] == 1                          # count stays int
+    assert row["PRDall"] == "{[1-133 (51.2 @ 5)];}"      # structured -> str
+    assert row["PRDothers"] == "{}"
+
+
+# --- errors / misuse (no jar needed) ----------------------------------------
+
+def test_missing_jar_raises():
+    with pytest.raises(plaac.PlaacError):
+        plaac.find_jar("/nonexistent/definitely/not/plaac.jar")
+
+
+def test_extra_args_str_raises_typeerror():
+    # A bare string would explode into single characters via list(); reject it
+    # (raised before any jar/env work, so no jar needed).
+    with pytest.raises(TypeError):
+        plaac.run(_EXAMPLE, extra_args="-s")
+
+
+@requires_jar
+def test_missing_input_raises():
+    with pytest.raises(plaac.PlaacError):
+        plaac.run("/nonexistent/input.fasta")
+
+
+# --- end-to-end (require jar + java) ----------------------------------------
+
+@requires_jar
+def test_four_classic_prions():
+    run = plaac.run(_EXAMPLE, alpha=1, core_length=60)
+    assert run.returncode == 0
+    assert run.rows is not None
+    assert sorted(r["SEQid"] for r in run.rows) == sorted(_CLASSIC)
+
+
+@requires_jar
+def test_all_four_are_prd_positive():
+    run = plaac.run(_EXAMPLE, alpha=1, core_length=60)
+    called = plaac.called_prlds(run.rows)
+    assert sorted(r["SEQid"] for r in called) == sorted(_CLASSIC)
+
+
+@requires_jar
+def test_per_residue_mode_returns_text_not_rows():
+    run = plaac.run(_EXAMPLE, alpha=1, core_length=60, print_list="all")
+    assert run.rows is None
+    assert len(run.stdout) > 0
+
+
+@requires_jar
+def test_failed_run_yields_no_rows():
+    # A bad numeric arg makes the jar exit non-zero; with check=False the wrapper
+    # must not fabricate rows from failed output.
+    run = plaac.run(_EXAMPLE, extra_args=["-c", "not_a_number"], check=False)
+    assert run.returncode != 0
+    assert run.rows is None
+
+
+@requires_jar
+def test_to_dataframe_raises_in_per_residue_mode():
+    run = plaac.run(_EXAMPLE, print_list="all")
+    with pytest.raises(plaac.PlaacError):
+        run.to_dataframe()
+
+
+# --- option pass-throughs (require jar) -------------------------------------
+
+@requires_jar
+def test_heap_option_sets_xmx():
+    run = plaac.run(_EXAMPLE, alpha=1, core_length=60, heap="256m")
+    assert "-Xmx256m" in run.command
+    assert run.returncode == 0
+    assert len(run.rows) == 4
+
+
+@requires_jar
+def test_background_fasta_option():
+    # alpha < 1 so the -b background actually influences scoring.
+    run = plaac.run(_EXAMPLE, alpha=0.5, core_length=60, background_fasta=_EXAMPLE)
+    assert "-b" in run.command
+    assert _EXAMPLE in run.command
+    assert run.returncode == 0
+    assert len(run.rows) == 4
+
+
+@requires_jar
+def test_background_freqs_option():
+    # Generate a frequency table the documented way ('-b FASTA' with no -i prints
+    # one), then feed it back via -B.
+    jar = str(plaac.find_jar())
+    freqs = subprocess.run(
+        ["java", "-jar", jar, "-b", _EXAMPLE],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as fh:
+        fh.write(freqs)
+        freqs_path = fh.name
+    try:
+        run = plaac.run(_EXAMPLE, alpha=0.5, core_length=60,
+                        background_freqs=freqs_path)
+        assert "-B" in run.command
+        assert freqs_path in run.command
+        assert run.returncode == 0
+        assert len(run.rows) == 4
+    finally:
+        os.unlink(freqs_path)

--- a/cli/python/test_plaac.py
+++ b/cli/python/test_plaac.py
@@ -159,6 +159,37 @@ def test_to_dataframe_raises_in_per_residue_mode():
         run.to_dataframe()
 
 
+# --- jar/package version-skew check (require jar) ---------------------------
+
+@requires_jar
+def test_get_jar_version_returns_string():
+    v = plaac.get_jar_version(plaac.find_jar())
+    assert isinstance(v, str) and v
+
+
+@requires_jar
+def test_check_version_ok_when_unknown_or_matching():
+    # From a source checkout __version__ is "unknown", so check_version is a
+    # no-op and returns the jar version without raising.
+    v = plaac.check_version(plaac.find_jar())
+    assert isinstance(v, str) and v
+
+
+@requires_jar
+def test_check_version_raises_on_mismatch(monkeypatch):
+    monkeypatch.setattr(plaac, "__version__", "9.9.9-does-not-match")
+    with pytest.raises(plaac.PlaacError):
+        plaac.check_version(plaac.find_jar())
+
+
+@requires_jar
+def test_run_skips_version_check_when_disabled(monkeypatch):
+    # A deliberately mismatched version must not raise when the check is off.
+    monkeypatch.setattr(plaac, "__version__", "9.9.9-does-not-match")
+    run = plaac.run(_EXAMPLE, alpha=1, core_length=60, check_jar_version=False)
+    assert run.returncode == 0
+
+
 # --- option pass-throughs (require jar) -------------------------------------
 
 @requires_jar


### PR DESCRIPTION
As offered in #19 a small, self-contained Python wrapper so PLAAC can be driven from scripts/pipelines rather than shelling out by hand. Everything lives under `cli/python/`; **no changes to `plaac.java`**, so the MOT3 gold test is unaffected.

## API
```python
import plaac
run = plaac.run("cli/example/four_classic_prions.fasta", alpha=1, core_length=60)
for r in plaac.called_prlds(run.rows):          # proteins with PRDlen > 0
    print(r["SEQid"], r["PRDscore"], r["PRDlen"])
df = run.to_dataframe()                          # optional; requires pandas
```
- `plaac.run(...)` → locates `plaac.jar`, runs it, returns a `PlaacRun` (command / returncode / stdout / stderr / parsed rows).
- `plaac.parse_summary(text)` → per-protein TSV to dicts (numeric coercion, `NA`/`NaN`→`None`; name/sequence columns incl. `PRDall`/`PRDothers` kept as strings).
- `plaac.called_prlds(rows)` → PrLD-positive proteins.
- `PlaacRun.to_dataframe()` → pandas DataFrame (**pandas optional**, lazily imported).

## Standard-library only, defensive
No required dependencies (pandas optional). Encodes details a raw subprocess misses: jar auto-discovery (strict on an explicit `jar=`/`$PLAAC_JAR`), a JVM-locale pin for reproducible number formatting, an `-Xmx` knob, a `timeout` (PLAAC prints no progress), and a non-zero-exit check. `parse_summary` **raises** rather than silently returning `[]` when the column header is missing, or when a row has more fields than the header (format drift) — surfaced, not swallowed.

## Tests
`cli/python/test_plaac.py` (stdlib `unittest`, no pytest) — 19 tests covering parsing, error/malformed-output paths, the `-b`/`-B`/`-Xmx` pass-throughs, and an end-to-end run of the four classic prions. Wired into the existing `cli-unit-test.yml` as a step (runs on the Java 11/17 matrix). `pyproject.toml` makes it pip-installable.

Thanks for taking a look!