### PR TITLE
container versioning and deployment improvements

### DIFF
--- a/.github/workflows/web-container.yml
+++ b/.github/workflows/web-container.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: whitehead/plaac-web
+  IMAGE_NAME: ${{ github.repository_owner }}/plaac-web
 
 jobs:
   build:

--- a/.github/workflows/web-container.yml
+++ b/.github/workflows/web-container.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           VERSION=$(./cli/get_plaac_version.sh)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "PLAAC version: $VERSION"
+          echo "PLAAC Version: $VERSION"
           
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/web-container.yml
+++ b/.github/workflows/web-container.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine PLAAC version
+        id: version
+        run: |
+          VERSION=$(./cli/get_plaac_version.sh)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "PLAAC version: $VERSION"
+          
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -52,5 +59,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PLAAC_VERSION=${{ steps.version.outputs.version }}          
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/cli/build_plaac.sh
+++ b/cli/build_plaac.sh
@@ -5,9 +5,12 @@ cd $SCRIPT_DIR
 
 # now get the package version
 
-echo "getting version"
-
-PLAAC_VERSION=$(./get_plaac_version.sh)
+if [ -n "${PLAAC_VERSION:-}" ]; then
+    echo "using supplied version: ${PLAAC_VERSION}"
+else
+    echo "getting version"
+    PLAAC_VERSION=$(./get_plaac_version.sh)
+fi
 
 echo "ok (Version: ${PLAAC_VERSION})"
 

--- a/cli/get_plaac_version.sh
+++ b/cli/get_plaac_version.sh
@@ -11,10 +11,10 @@ fi
 
 . "$VENV/bin/activate"
 
-python -m pip install --upgrade pip >/dev/null
-python -m pip install -q "setuptools-scm>=8,<9"
+python3 -m pip install --upgrade pip >/dev/null
+python3 -m pip install -q "setuptools-scm>=8,<9"
 
-python - <<'EOF'
+python3 - <<'EOF'
 from setuptools_scm import get_version
 
 print(get_version(

--- a/cli/get_plaac_version.sh
+++ b/cli/get_plaac_version.sh
@@ -14,14 +14,4 @@ fi
 
 python3 -m pip install --upgrade pip >/dev/null
 python3 -m pip install -q "setuptools-scm>=8,<9"
-
-python3 - <<'EOF'
-from setuptools_scm import get_version
-
-print(get_version(
-    root=$REPO_ROOT,
-    version_scheme="guess-next-dev",
-    local_scheme="node-and-date",
-    fallback_version="1.1.0.dev0",
-))
-EOF
+python -m setuptools_scm  --root "$REPO_ROOT" --config "$SCRIPT_DIR/python/pyproject.toml"

--- a/cli/get_plaac_version.sh
+++ b/cli/get_plaac_version.sh
@@ -2,6 +2,7 @@
 set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 VENV="$SCRIPT_DIR/.build-venv"
 
 if [ ! -d "$VENV" ]; then
@@ -18,7 +19,7 @@ python3 - <<'EOF'
 from setuptools_scm import get_version
 
 print(get_version(
-    root="..",
+    root=$REPO_ROOT,
     version_scheme="guess-next-dev",
     local_scheme="node-and-date",
     fallback_version="1.1.0.dev0",

--- a/web/deploy/setup-plaac-server.sh
+++ b/web/deploy/setup-plaac-server.sh
@@ -7,32 +7,21 @@ QUADLET_DIR="${HOME}/.config/containers/systemd"
 CONTAINER_IMAGE="${1:-${IMAGE:-}}"
 IMAGE="${CONTAINER_IMAGE:-localhost/plaac-web:latest}"
 DOMAIN="${DOMAIN:-}"
-PLAAC_VERSION=$("$REPO_DIR/cli/get_plaac_version.sh")
 
 if [ -f /etc/debian_version ] && command -v apt-get >/dev/null 2>&1; then
-    packages=()
-
-    if ! command -v podman >/dev/null 2>&1; then
-        packages+=(podman)
-    fi
-
-    if ! command -v caddy >/dev/null 2>&1; then
-        packages+=(caddy)
-    fi
-
-    if [ "${#packages[@]}" -gt 0 ]; then
-        echo "Installing host dependencies: ${packages[*]}..."
-        sudo apt-get update
-        sudo apt-get install -y "${packages[@]}"
-    fi
+    echo "Installing host dependencies..."
+    sudo apt-get update
+    sudo apt-get install -y podman caddy python3-venv
 else
-    if ! command -v podman >/dev/null 2>&1; then
-        echo "error: podman is not installed and automatic installation is only supported on Debian" >&2
-        exit 1
-    fi
+    for command in podman caddy python3; do
+        if ! command -v "$command" >/dev/null 2>&1; then
+            echo "error: $command is not installed and automatic installation is only supported on Debian" >&2
+            exit 1
+        fi
+    done
 
-    if ! command -v caddy >/dev/null 2>&1; then
-        echo "error: caddy is not installed and automatic installation is only supported on Debian" >&2
+    if ! python3 -c 'import venv' >/dev/null 2>&1; then
+        echo "error: Python venv support is not installed" >&2
         exit 1
     fi
 fi
@@ -41,6 +30,7 @@ if [ -n "$CONTAINER_IMAGE" ]; then
     echo "Using container image $IMAGE..."
     podman pull "$IMAGE"
 else
+    PLAAC_VERSION=$("$REPO_DIR/cli/get_plaac_version.sh")
     echo "Building $IMAGE..."
     podman build  --build-arg "PLAAC_VERSION=$PLAAC_VERSION" --cgroup-manager=cgroupfs --format docker -t "$IMAGE" -f "$REPO_DIR/web/Dockerfile" "$REPO_DIR"
 fi


### PR DESCRIPTION
- Unified PLAAC version detection for CLI, Python package, local container builds, and CI using `setuptools-scm` command-line, and reference `cli/python/pyproject.toml` so all config is one place.
- Updated container builds to pass the resolved version into the Docker build, avoiding dependence on .git inside the build container.
- Updated server setup to install the Python venv dependency when building containers locally.
- Made the GitHub Actions container workflow fork-friendly by deriving the GHCR image name from the repository owner.
- simplify installation of required packages on Debian
- require `python3-venv` on server