### PR TITLE
Keep SEQid to a single field in the output tables

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,10 +43,11 @@ jobs:
         run: |
           ./build_plaac.sh
 
-      - name: Run MOT3 regression and input-validation tests
+      - name: Run MOT3 regression, input-validation and SEQid-field tests
         run: |
           bash tests/test_mot3.sh --no-build
           bash tests/test_input_validation.sh --no-build
+          bash tests/test_seqid_field.sh --no-build
           
       - name: Upload jar artifact
         if: matrix.java == 11

--- a/cli/src/plaac.java
+++ b/cli/src/plaac.java
@@ -331,6 +331,21 @@ class plaac {
 	}
     }
 
+    // Sequence names are taken verbatim from the FASTA header, and both output tables are
+    // tab-delimited, so a tab inside a header would split SEQid across several fields and
+    // shift every column after it. Map tabs, newlines and other control characters to
+    // spaces, and trim, so that SEQid is always exactly one field. Names that contain no
+    // control characters and no leading or trailing whitespace are returned unchanged.
+    static String tsvSafeName (String s) {
+	if (s == null) return "";
+	StringBuilder sb = new StringBuilder(s.length());
+	for (int i=0; i<s.length(); i++) {
+	    char c = s.charAt(i);
+	    sb.append((c == '\t' || c == '\n' || c == '\r' || Character.isISOControl(c)) ? ' ' : c);
+	}
+	return sb.toString().trim();
+    }
+
     public static void main (String args[]) {
 
 	plaac ms = new plaac(); 
@@ -728,7 +743,7 @@ class plaac {
 		//  dr.printme(genecount + "\t" + name);
 		for (int i=0; i<seq.length; i++) {
                     // print i+1 rather than i, for one-based indices
-		    System.out.print(id + "\t" + nm + "\t" + (i+1) + "\t" + aanames[seq[i]] + "\t" + hmm1.viterbipath[i] + "\t" + hmm1.mappath[i]+"\t");
+		    System.out.print(id + "\t" + tsvSafeName(nm) + "\t" + (i+1) + "\t" + aanames[seq[i]] + "\t" + hmm1.viterbipath[i] + "\t" + hmm1.mappath[i]+"\t");
 		    System.out.format("%.4f\t%.4f\t%.8f\t%.4f\t%.8f\t%.8f\t%.4f\t%.8f", dr.charge[i], dr.hydro[i], dr.fi[i], 
 				      dr.plaacllr[i], dr.papa[i], dr.fix2[i], dr.plaacllrx2[i], dr.papax2[i]);
                     // use exp format here? not a big deal for plotting, but if we want to take logs later could be helpful
@@ -1083,7 +1098,7 @@ class plaac {
 	    } else {
 		// use one-based indices for output table (e.g, first AA is at position 1); zero-based is used internally.
 		System.out.format("%s\t%d\t%d\t%d\t%d\t%.3f\t%d\t%d\t%d\t%.3f\t%d\t%.3f\t%d\t%d\t%d\t%.3f\t%d\t%d\t%d\t%d\t%.3f\t%.3f\t",
-				  nm,
+				  tsvSafeName(nm),
 				  (int) inf2nan(hs1[2]), 
 				  (int) (hs1[0]+1), (int) (hs1[1]+1), // one-based
 				  (int) (hs1[1]-hs1[0]+1), 
@@ -4603,8 +4618,7 @@ class fastareader {
 		}
 		else if (line.charAt(0) == '>') {
 		    ondeck = true;
-		    name = line.substring(1);
-		    name.trim();
+		    name = line.substring(1).trim();
 		    return sb;
 		}
 		else sb.append(line);

--- a/cli/tests/test_seqid_field.sh
+++ b/cli/tests/test_seqid_field.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Tests that SEQid always occupies exactly one field of the tab-delimited output.
+#
+# Sequence names are taken verbatim from the FASTA header, so before the fix that
+# accompanies these tests a tab inside a header split SEQid across several fields and
+# shifted every column after it. Nothing errored: the header row kept its 41 columns
+# while data rows gained one per tab, so anything reading the table by column index
+# silently read the wrong values. MitoCarta and several other curated FASTA
+# distributions ship tab-separated headers, which is how this is met in practice.
+#
+# A second, related inconsistency: the name captured in fastareader.nextfasta()
+# discarded the result of its trim(), so the first record (whose name comes from
+# hasmorefastas(), which does trim) lost trailing whitespace while every later record
+# kept it. The same file could therefore produce a different column count for its
+# first record than for the rest.
+#
+# Usage:
+#   cli/tests/test_seqid_field.sh            # builds plaac.jar if missing
+#   cli/tests/test_seqid_field.sh --no-build # require an existing jar
+#
+# Exits non-zero if any test fails.
+
+source "$(dirname "$0")/test_common.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -f "$OUT" "$ERR"; rm -rf "$WORK"' EXIT
+
+SEQ=MQNSNQSQNQGQFQQNNMQQQQQQQQQQNQFQQNMPMHQFNMQNQGQFQQNGMQPQFHQQ
+
+# field counts of the header row and of every data row, ignoring "#" comment lines
+header_cols() { grep -v '^#' "$1" | awk -F'\t' 'NR==1 {print NF; exit}'; }
+data_cols()   { grep -v '^#' "$1" | awk -F'\t' 'NR>1 {print NF}' | sort -u | tr '\n' ' '; }
+
+echo "Running SEQid field tests..."
+
+# 1. a tab inside the header must not add columns
+printf '>sp|P00001|TEST_HUMAN\tGeneID:1\tMYGENE\n%s\n' "$SEQ" > "$WORK/tab_header.fasta"
+run -i "$WORK/tab_header.fasta"
+h="$(header_cols "$OUT")"; d="$(data_cols "$OUT")"
+if [[ "$rc" -eq 0 && "$d" == "$h " ]]; then
+    pass_msg "tab in header keeps the data row at $h columns"
+else
+    fail_msg "tab in header changed the column count (header=$h data=$d exit=$rc)"
+fi
+
+# 2. the tab-separated and space-separated forms of one header agree in every field
+printf '>sp|P00001|TEST_HUMAN GeneID:1 MYGENE\n%s\n' "$SEQ" > "$WORK/space_header.fasta"
+run -i "$WORK/space_header.fasta"; grep -v '^#' "$OUT" > "$WORK/space.tsv"
+run -i "$WORK/tab_header.fasta";   grep -v '^#' "$OUT" > "$WORK/tab.tsv"
+if diff -q "$WORK/space.tsv" "$WORK/tab.tsv" >/dev/null; then
+    pass_msg "tab-separated and space-separated headers give identical tables"
+else
+    fail_msg "tab-separated header does not match the space-separated form"
+    diff "$WORK/space.tsv" "$WORK/tab.tsv" | sed 's/^/        /' | head -6
+fi
+
+# 3. every record of a multi-record file gets the same column count, whatever
+#    trailing whitespace its header carries
+printf '>REC_ONE\t\n%s\n>REC_TWO\t\n%s\n' "$SEQ" "$SEQ" > "$WORK/trailing_tab.fasta"
+run -i "$WORK/trailing_tab.fasta"
+h="$(header_cols "$OUT")"; d="$(data_cols "$OUT")"
+if [[ "$rc" -eq 0 && "$d" == "$h " ]]; then
+    pass_msg "trailing tabs give every record $h columns"
+else
+    fail_msg "trailing tab produced uneven rows (header=$h data=$d exit=$rc)"
+fi
+
+printf '>REC_ONE   \n%s\n>REC_TWO   \n%s\n' "$SEQ" "$SEQ" > "$WORK/trailing_space.fasta"
+run -i "$WORK/trailing_space.fasta"
+names="$(grep -v '^#' "$OUT" | awk -F'\t' 'NR>1 {print $1}' | tr '\n' ',')"
+if [[ "$names" == "REC_ONE,REC_TWO," ]]; then
+    pass_msg "trailing spaces are trimmed consistently across records"
+else
+    fail_msg "trailing spaces handled inconsistently (SEQids: $names)"
+fi
+
+# 4. names without control characters must be untouched, embedded spaces and all
+run -i "$CLI_DIR/example/four_classic_prions.fasta"
+if [[ "$rc" -eq 0 && "$(grep -cE '^(Sup35p|Ure2p|Rnq1p|Mot3p)' "$OUT")" -eq 4 ]]; then
+    pass_msg "ordinary names are unchanged"
+else
+    fail_msg "ordinary names regressed (exit=$rc)"
+fi
+
+# 5. the per-residue table (-p) puts SEQid in one field as well
+run -i "$WORK/space_header.fasta" -p all; grep -v '^#' "$OUT" | grep -v '^###' > "$WORK/space_res.tsv"; rc_s=$rc
+run -i "$WORK/tab_header.fasta"   -p all; grep -v '^#' "$OUT" | grep -v '^###' > "$WORK/tab_res.tsv"
+if [[ "$rc" -eq 0 && "$rc_s" -eq 0 ]] && diff -q "$WORK/space_res.tsv" "$WORK/tab_res.tsv" >/dev/null; then
+    pass_msg "per-residue table matches between tab- and space-separated headers"
+else
+    fail_msg "per-residue table differs between tab- and space-separated headers (exit=$rc)"
+    diff "$WORK/space_res.tsv" "$WORK/tab_res.tsv" | sed 's/^/        /' | head -4
+fi
+
+echo
+if [[ "$fail" -eq 0 ]]; then
+    echo "All SEQid field tests passed."
+else
+    echo "Some SEQid field tests FAILED."
+fi
+exit "$fail"


### PR DESCRIPTION
I've rebased #41 against `master`.

Here is @ssiddhantsharma original comment:

> Sequence names are copied verbatim from the FASTA header into the SEQid column of both output tables, which are tab-delimited. A tab inside a header therefore split SEQid across several fields and shifted every column after it. Nothing failed: the header row kept its 41 columns while affected data rows gained one field per tab, so anything reading the table by column index silently read values from the wrong columns. MitoCarta and several other curated FASTA distributions ship tab-separated headers, which is how this is usually met.

> A related inconsistency came from fastareader.nextfasta(), which discarded the result of its trim(). The first record of a file takes its name from hasmorefastas(), which does trim, while later records took it from nextfasta(), which did not. A file whose headers carried trailing whitespace could therefore produce a different column count for its first record than for the rest.

> Map tabs, newlines and other control characters in the name to spaces and trim it, so SEQid is always exactly one field, and assign the trimmed name in nextfasta(). Names without control characters or surrounding whitespace are unchanged, embedded spaces included, so the MOT3 golden output is byte-identical.

> cli/tests/test_seqid_field.sh covers a tab inside a header, agreement between the tab- and space-separated forms of the same header, trailing tabs and spaces across a multi-record file, the per-residue table under -p, and that ordinary names are left alone. Five of its six checks fail without this change. Wired into cli.yml alongside the MOT3 and input-validation tests.